### PR TITLE
[BACKLOG-26140] - Moved kettle-core to a provided scope and lifted some exclusions to fix a runtime error.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
         <groupId>pentaho-kettle</groupId>
         <artifactId>kettle-core</artifactId>
         <version>${pdi.version}</version>
+        <scope>provided</scope>
       </dependency>
 	  
       <!-- 'RUNTIME' SCOPED DEPS -->


### PR DESCRIPTION
Fixes a weka-scoring plugin runtime issue.